### PR TITLE
Proper javascript evaluation 

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -455,7 +455,7 @@ browser emulator with it:
 
     // evaluate JS expression:
     echo $session->evaluateScript(
-        "(function(){ return 'something from browser'; })()"
+        "return 'something from browser';"
     );
 
     // wait for n milliseconds or


### PR DESCRIPTION
You get null if you pass anonymous function as evaluateScript method parameter.

Look at http://github.com/Behat/MinkSelenium2Driver/issues/61
