### PR TITLE
add option "php composer.phar"

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -28,8 +28,11 @@ The recommended way to install Mink with all its dependencies is through
     $ composer require behat/mink
 
 .. note::
-    For local installations of composer you must call it like this: ``$ php composer.phar require behat/mink`` .
-    In this case you must use the different call ``php composer.phar`` everywhere instead of the simple command ``composer``.
+
+    For local installations of composer you must call it like this:
+    ``$ php composer.phar require behat/mink`` .
+    In this case you must use the different call 
+    ``php composer.phar`` everywhere instead of the simple command ``composer``.
 
 Everything will be installed inside ``vendor`` folder.
 Finally, include Composer autoloading script to your project:

--- a/index.rst
+++ b/index.rst
@@ -27,6 +27,12 @@ The recommended way to install Mink with all its dependencies is through
 
     $ composer require behat/mink
 
+Or
+
+.. code-block:: bash
+
+    $ php composer.phar require behat/mink
+
 Everything will be installed inside ``vendor`` folder.
 Finally, include Composer autoloading script to your project:
 

--- a/index.rst
+++ b/index.rst
@@ -27,11 +27,9 @@ The recommended way to install Mink with all its dependencies is through
 
     $ composer require behat/mink
 
-Or
-
-.. code-block:: bash
-
-    $ php composer.phar require behat/mink
+.. note::
+    For local installations of composer you must call it like this: ``$ php composer.phar require behat/mink`` .
+    In this case you must use the different call ``php composer.phar`` everywhere instead of the simple command ``composer``.
 
 Everything will be installed inside ``vendor`` folder.
 Finally, include Composer autoloading script to your project:


### PR DESCRIPTION
If you install composer, then you only get the composer,.phar executable file. A command 'composer' is not present.