### PR TITLE
Adding "livehtml" build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ html:
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+livehtml:
+	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo


### PR DESCRIPTION
The new "livehtml" target for "make" command allows to:
- serve generated documentation on 8000 port
- automatically reload browser when RST files used on opened page are changed