### PR TITLE
Update at-a-glance.rst

### DIFF
--- a/at-a-glance.rst
+++ b/at-a-glance.rst
@@ -1,7 +1,7 @@
 Mink at a Glance
 ================
 
-There's huge amount of browser emulators out there, like `Goutte`_, `Selenium`_,
+There's huge number of browser emulators out there, like `Goutte`_, `Selenium`_,
 `Sahi`_ and others. They all do the same job, but do it very differently.
 They behave differently and have very different API's. But, what's more important,
 there is actually 2 completely different types of browser emulators out there:


### PR DESCRIPTION
Grammatical error. In English, when you have a large amount of something, the 'something' has to be an 'uncountable' thing, such as sand or water, or sunshine. If you have a large number of things that are countable, such as 'browsers' or bricks, or cars then it should be "A large number of <countable things>"