### PR TITLE
Adding note to install xcode to use zombie.js

### DIFF
--- a/drivers/zombie.rst
+++ b/drivers/zombie.rst
@@ -12,6 +12,11 @@ the system.
 Installation
 ------------
 
+.. note::
+
+    On Mac you need to install Xcode for zombie.js to work.
+    https://developer.apple.com/xcode/
+
 ZombieDriver is available through Composer:
 
 .. code-block:: bash


### PR DESCRIPTION
On Mac you need to have Xcode installed for zombie.js to work.
I hope the format of the docs is ok. Is there any way to preview how it will render?