### PR TITLE
Use correct composer package name

### DIFF
--- a/drivers/selenium.rst
+++ b/drivers/selenium.rst
@@ -19,7 +19,7 @@ SeleniumDriver is available through Composer:
 
 .. code-block:: bash
 
-    $ composer require behat/mink-selenium-driver
+    $ composer require behat/mink-selenium2-driver
 
 In order to talk with the selenium server, you should install and configure
 it first:


### PR DESCRIPTION
The  package to install should be `behat/mink-selenium2-driver`, in regard to the **caution section** just above !