### PR TITLE
Mention Chromedriver is async

### DIFF
--- a/guides/interacting-with-pages.rst
+++ b/guides/interacting-with-pages.rst
@@ -15,6 +15,12 @@ the links and press the buttons on the page.
     These methods are actually equivalent internally (pressing a button involves
     clicking on it). Having both methods allows the code to be more readable.
 
+.. note::
+
+    Some drivers, notably Chromedriver is async and you need to wait for the 
+    results to arrive. The ``Element::waitFor`` helper method makes this easier.
+
+
 .. _interacting-with-forms:
 
 Interacting with Forms


### PR DESCRIPTION
I have written my first test this last week using Mink and Chromedriver and it really is not clear Chromedriver is async. If this pull request is accepted, I will add notes to some method doxygen as well and perhaps provide sample code. Drupal 8.5.0 has

    public function waitForElement($selector, $locator, $timeout = 10000) {
      $page = $this->session->getPage();

      $result = $page->waitFor($timeout / 1000, function () use ($page, $selector, $locator) {
        return $page->find($selector, $locator);
      });

      return $result;
    }

which is really helpful, what would be a good place to put this in the Mink documentation -- or perhaps the codebase?